### PR TITLE
Add licensing information to gemspec.

### DIFF
--- a/async-rest.gemspec
+++ b/async-rest.gemspec
@@ -4,6 +4,7 @@ require_relative 'lib/async/rest/version'
 Gem::Specification.new do |spec|
 	spec.name          = "async-rest"
 	spec.version       = Async::REST::VERSION
+	spec.licenses      = ["MIT"]
 	spec.authors       = ["Samuel Williams"]
 	spec.email         = ["samuel.williams@oriontransfer.co.nz"]
 


### PR DESCRIPTION
This should make it easier for automated tools to find out what license is used.