### PR TITLE
fix issues with Representation index operator

### DIFF
--- a/lib/async/rest/representation.rb
+++ b/lib/async/rest/representation.rb
@@ -31,7 +31,7 @@ module Async
 		# A representation consists of data, metadata describing the data, and, on occasion, metadata to describe the metadata (usually for the purpose of verifying message integrity). Metadata is in the form of name-value pairs, where the name corresponds to a standard that defines the value's structure and semantics. Response messages may include both representation metadata and resource metadata: information about the resource that is not specific to the supplied representation.
 		class Representation
 			def self.[] wrapper
-				klass = Class.new(Representation)
+				klass = Class.new(self)
 				
 				klass.const_set(:WRAPPER, wrapper)
 				
@@ -67,7 +67,7 @@ module Async
 			end
 			
 			def with(klass = self.class, **options)
-				klass.new(@resource.with(**options), wrapper: @wrapper)
+				klass.new(@resource.with(**options), wrapper: klass::WRAPPER.new)
 			end
 			
 			def [] **parameters

--- a/lib/async/rest/version.rb
+++ b/lib/async/rest/version.rb
@@ -22,6 +22,6 @@
 
 module Async
 	module REST
-		VERSION = "0.12.2"
+		VERSION = "0.12.3"
 	end
 end

--- a/lib/async/rest/version.rb
+++ b/lib/async/rest/version.rb
@@ -22,6 +22,6 @@
 
 module Async
 	module REST
-		VERSION = "0.12.3"
+		VERSION = "0.12.2"
 	end
 end


### PR DESCRIPTION
## Description

As I understood it the purpose of the static `[]` operator was to get a version of `Representation` with a different wrapper set on it, but using it for this had two issues:

* It didn't respect the class it was called on. Inheriting from `Representation` and calling `.[...]` would give you the base class, not the child class.
* The `@wrapper` was used to select a wrapper on the `with` method which is meant to support passing alternate classes, and therefore `Representation.new.with(MyRepresentation, ...)` would use the wrapper configured on `Representation` and not the one configured on `MyRepresentation`.