### PR TITLE
Fix code example in getting started guide

### DIFF
--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -27,34 +27,34 @@ Generally speaking, you should model your interface around representations. Each
 require 'async/rest'
 
 module DNS
-	class Query < Async::REST::Representation[Async::REST::Wrapper::JSON]
-		def question
-			value[:Question]
-		end
-		
-		def answer
-			value[:Answer]
-		end
-	end
-	
-	class Client < Async::REST::Resource
-		# This is the default endpoint to use unless otherwise specified:
-		ENDPOINT = Async::HTTP::Endpoint.parse('https://dns.google/resolve')
-		
-		# Resolve a DNS query.
-		def resolve(name, type)
-			self.call(Query, name: name, type: type)
-		end
-	end
+  class Query < Async::REST::Representation[Async::REST::Wrapper::JSON]
+    def question
+      value[:Question]
+    end
+
+    def answer
+      value[:Answer]
+    end
+  end
+
+  class Client < Async::REST::Resource
+    # This is the default endpoint to use unless otherwise specified:
+    ENDPOINT = Async::HTTP::Endpoint.parse('https://dns.google/resolve')
+
+    # Resolve a DNS query.
+    def resolve(name, type)
+      Query.get(self.with(parameters: { name: name, type: type }))
+    end
+  end
 end
 
 DNS::Client.open do |client|
-	query = client.resolve('example.com', 'AAAA')
-	
-	puts query.question
-	# {:name=>"example.com.", :type=>28}
-	puts query.answer
-	# {:name=>"example.com.", :type=>28, :TTL=>13108, :data=>"2606:2800:220:1:248:1893:25c8:1946"}
+  query = client.resolve('example.com', 'AAAA')
+
+  puts query.question
+  # {:name=>"example.com.", :type=>28}
+  puts query.answer
+  # {:name=>"example.com.", :type=>28, :TTL=>13108, :data=>"2606:2800:220:1:248:1893:25c8:1946"}
 end
 ```
 


### PR DESCRIPTION
The code example in the getting started guide wasn't working for me. It looks like there were some API changes causing it to break. I've amended it to a version that worked for me. 

Please let me know if there's a better way to accomplish this. I just hammered at the code until it worked.

## Types of Changes

- Documentation

## Contribution

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
