### PR TITLE
Fix logic to parse JSON responses in Form wrapper

### DIFF
--- a/lib/async/rest/wrapper/form.rb
+++ b/lib/async/rest/wrapper/form.rb
@@ -34,10 +34,9 @@ module Async
 				end
 				
 				def parser_for(response)
-					if content_type = response.headers["content-type"]
-						if parser = @content_types[content_type]
-							return parser
-						end
+					content_type, _ = response.headers["content-type"].split(";")
+					if content_type && parser = @content_types[content_type]
+						return parser
 					end
 					
 					return super

--- a/lib/async/rest/wrapper/form.rb
+++ b/lib/async/rest/wrapper/form.rb
@@ -34,8 +34,8 @@ module Async
 				end
 				
 				def parser_for(response)
-					content_type, _ = response.headers["content-type"].split(";")
-					if content_type && parser = @content_types[content_type]
+					media_type, _ = response.headers["content-type"].split(";")
+					if media_type && parser = @content_types[media_type]
 						return parser
 					end
 					


### PR DESCRIPTION
When using the form wrapper, there's a mechanism to process JSON encoded responses, but this won't work if the `content-type` header isn't EXACTLY `application/json`. It can sometimes be `application/json; charset=UTF8` or something like that.

This change splits the string on the `;` and uses the first part to lookup the parser.

I'm not sure what the best way to test this is though.

## Types of Changes

- Bug fix.

## Contribution

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
